### PR TITLE
Only install a custom exception handler when the target CPU is x64.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -276,7 +276,6 @@ component("base") {
     "mac/bundle_locations.mm",
     "mac/call_with_eh_frame.cc",
     "mac/call_with_eh_frame.h",
-    "mac/call_with_eh_frame_asm.S",
     "mac/cocoa_protocols.h",
     "mac/dispatch_source_mach.cc",
     "mac/dispatch_source_mach.h",
@@ -642,6 +641,13 @@ component("base") {
     "win/wrapped_window_proc.cc",
     "win/wrapped_window_proc.h",
   ]
+
+
+  if (current_cpu == "x64") {
+    sources += [ "mac/call_with_eh_frame_asm.S" ]
+  } else {
+    sources += [ "mac/call_with_eh_frame_fallback.cc" ]
+  }
 
   sources -= [
     "sys_info_freebsd.cc",

--- a/mac/call_with_eh_frame_fallback.cc
+++ b/mac/call_with_eh_frame_fallback.cc
@@ -1,0 +1,15 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/mac/call_with_eh_frame.h"
+
+namespace base {
+namespace mac {
+
+void CallWithEHFrame(void (^block)(void)) {
+  block();
+}
+
+}  // namespace mac
+}  // namespace base


### PR DESCRIPTION
Adds a fallback otherwise.